### PR TITLE
Add support for show-optional and show-undeclared

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -4,7 +4,12 @@ use colored::*;
 use std::fs;
 use std::path::PathBuf;
 
-pub fn check_command(dir: &PathBuf, show_undeclared: bool, silent: bool) {
+pub fn check_command(
+    dir: &PathBuf,
+    silent: bool,
+    show_undeclared: bool,
+    show_missing_optional: bool,
+) {
     if !silent {
         println!("{}", "Checking environment...".cyan());
     }
@@ -75,7 +80,7 @@ pub fn check_command(dir: &PathBuf, show_undeclared: bool, silent: bool) {
         }
     }
 
-    if optional_missing_vars.len() > 0 && !silent {
+    if optional_missing_vars.len() > 0 && show_missing_optional {
         println!("{}", "Some optional variables are missing:".yellow().bold());
         for optional_var in optional_missing_vars {
             println!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,14 @@ struct Args {
     #[clap(short, long, parse(from_os_str), global = true)]
     dir: Option<PathBuf>,
 
+    /// Whether to print missing optional variables. Defaults to false.
+    #[clap(long, global = true)]
+    show_optional: bool,
+
+    /// Whether to show undeclared variables in output. Defaults to false.
+    #[clap(long, global = true)]
+    show_undeclared: bool,
+
     /// Command to execute if successful
     #[clap(subcommand)]
     command: Commands,
@@ -20,6 +28,8 @@ struct Args {
 enum Commands {
     /// Check if env has all required variables and warns if missing
     Check,
+
+    /// Any other command you want to execute
     #[clap(external_subcommand)]
     Other(Vec<String>),
 }
@@ -28,7 +38,9 @@ fn main() {
     let args = Args::parse();
     let dir = args.dir.unwrap_or_else(|| PathBuf::from("."));
     match args.command {
-        Commands::Check => checker::check_command(&dir, true, false),
-        Commands::Other(args) => runner::run_command(&dir, &args),
+        Commands::Check => checker::check_command(&dir, false, true, true),
+        Commands::Other(extra_args) => {
+            runner::run_command(&dir, &extra_args, args.show_undeclared, args.show_optional)
+        }
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2,8 +2,13 @@ use crate::checker;
 use std::path::PathBuf;
 use std::process::Command;
 
-pub fn run_command(dir: &PathBuf, command: &Vec<String>) {
-    checker::check_command(dir, false, true);
+pub fn run_command(
+    dir: &PathBuf,
+    command: &Vec<String>,
+    show_undeclared: bool,
+    show_missing_optional: bool,
+) {
+    checker::check_command(dir, false, show_undeclared, show_missing_optional);
     // Run the command with the given args
     let binary = command.get(0).unwrap();
     let other_args = command

--- a/tests/check_spec.rs
+++ b/tests/check_spec.rs
@@ -46,7 +46,7 @@ mod check_spec {
     fn run_check(
         fixture: &str,
         should_succeed: bool,
-        expected_out_put: &str,
+        expected_output: &str,
         env_vars: Option<Vec<(&str, &str)>>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let mut cmd = Command::cargo_bin("envful")?;
@@ -59,7 +59,7 @@ mod check_spec {
             }
         }
 
-        let predicate = predicate::str::contains(expected_out_put);
+        let predicate = predicate::str::contains(expected_output);
         if should_succeed {
             cmd.assert().success().stdout(predicate);
         } else {

--- a/tests/run_spec.rs
+++ b/tests/run_spec.rs
@@ -5,24 +5,54 @@ mod run_spec {
 
     #[test]
     fn runs_command_after_check() -> Result<(), Box<dyn std::error::Error>> {
-        run_run("success", true, "echo 'Hello world'", "Hello world")
+        run_run("success", true, "", "echo 'Hello world'", "Hello world")
+    }
+
+    #[test]
+    fn warns_optional_if_enabled() -> Result<(), Box<dyn std::error::Error>> {
+        run_run(
+            "optional_missing",
+            true,
+            "--show-optional",
+            "echo 'Hello world'",
+            "Missing optional variable",
+        )
+    }
+
+    #[test]
+    fn warns_undeclared_if_enabled() -> Result<(), Box<dyn std::error::Error>> {
+        run_run(
+            "undeclared",
+            true,
+            "--show-undeclared",
+            "echo 'Hello world'",
+            "Undeclared variable",
+        )
     }
 
     fn run_run(
         fixture: &str,
         should_succeed: bool,
+        envful_args: &str,
         command: &str,
-        expected_out_put: &str,
+        expected_output: &str,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let mut cmd = Command::cargo_bin("envful")?;
         let dir = format!("tests/fixtures/{}", fixture);
 
-        let command_args: Vec<&str> = command.split_whitespace().collect();
-        let run_args = ["-d", dir.as_str(), "--"];
+        let envful_args: Vec<&str> = envful_args.split_whitespace().collect();
+        let mut command_args: Vec<&str> = command.split_whitespace().collect();
+        command_args.insert(0, "--");
+        let run_args: Vec<&str> = ["-d", dir.as_str()]
+            .iter()
+            .chain(envful_args.iter())
+            .copied()
+            .collect();
+
         let all_args = run_args.iter().chain(command_args.iter());
         cmd.args(all_args);
 
-        let predicate = predicate::str::contains(expected_out_put);
+        let predicate = predicate::str::contains(expected_output);
         if should_succeed {
             cmd.assert().success().stdout(predicate);
         } else {


### PR DESCRIPTION
This PR adds support for two new flags to the run command: `--show-optional` and `--show-undeclared`.

These are useful if a team decides they want to be warned even on cases that do not exit the process with an error code.